### PR TITLE
CHEF-25298 - quick-archive - add_archive_note_to_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Archived Repository
+
+This repository has been archived and will no longer receive updates.  
+It was archived as part of the [Repository Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025).  
+If you are a Chef customer and need support for this repository, please contact your Chef account team.  
+
+---
+
 # community_cookbook_releaser
 A simple script to aid in version bumps and changelog generation for Chef managed community cookbooks
 


### PR DESCRIPTION
This PR adds an archive notice to the top of the README to indicate that this repository is being archived as part of the Repository Standardization Initiative.
The note informs users that the repository will no longer receive updates and provides guidance for Chef customers seeking support.